### PR TITLE
Update ssd1306_i2c.py

### DIFF
--- a/displays/ssd1306_i2c.py
+++ b/displays/ssd1306_i2c.py
@@ -44,7 +44,7 @@ class ssd1306_i2c():
 		self.fp = font.fontpkg
 
 		serial = i2c(port=i2c_port, address=i2c_address)
-		self.device = ssd1306(serial)
+		self.device = ssd1306(serial, cols, rows)
 
 
 	def clear(self):


### PR DESCRIPTION
Initialize luma oled driver with actual height and width parameters, so other displays apart from 128x64 can be used.