### PR TITLE
Fix a typo for a 'ttext' widget

### DIFF
--- a/displays/display.py
+++ b/displays/display.py
@@ -283,7 +283,7 @@ class gwidget(widget):
 
 	def update(self, reset=False):
 
-		if self.type in ['text', 'ttest', 'progressbar']:
+		if self.type in ['text', 'ttext', 'progressbar']:
 			if not self.changed(self.variables):
 				return False
 


### PR DESCRIPTION
This typo prevented use of scroll effect for Truetype text. At least I guess that was a typo and not deliberate.