### PR TITLE
working mcp23008 driver

### DIFF
--- a/displays/__init__.py
+++ b/displays/__init__.py
@@ -1,4 +1,4 @@
-__all__ = [ "display", "graphics", "winstar_weg", "ssd1306_i2c", "hd44780", "hd44780_i2c", "luma_i2c", "lcd_curses", "fonts" ]
+__all__ = [ "display", "graphics", "winstar_weg", "ssd1306_i2c", "hd44780", "hd44780_i2c", "hd44780_mcp23008", "luma_i2c", "lcd_curses", "fonts" ]
 
 
 import display
@@ -9,4 +9,5 @@ import ssd1306_i2c
 import luma_i2c
 import hd44780
 import hd44780_i2c
+import hd44780_mcp23008
 import fonts

--- a/pydPiper.py
+++ b/pydPiper.py
@@ -715,7 +715,7 @@ if __name__ == u'__main__':
     elif driver == u"hd44780_i2c":
         lcd = displays.hd44780_i2c.hd44780_i2c(rows, cols, i2c_address, i2c_port, enable)
     elif driver == u"hd44780_mcp23008":
-        lcd = displays.hd44780_i2c.hd44780_mcp23008(rows, cols, i2c_address, i2c_port, enable)
+        lcd = displays.hd44780_mcp23008.hd44780_mcp23008(rows, cols, i2c_address, i2c_port, enable)
     elif driver == u"ssd1306_i2c":
         lcd = displays.ssd1306_i2c.ssd1306_i2c(rows, cols, i2c_address, i2c_port)
     elif driver == u"luma_i2c":


### PR DESCRIPTION
Set IO direction to output on all GPIOs on mcp23008
Changed from write_byte to write_byte_data with mcp23008 gpio pin
Fixed references to module

Changes according to RPLCD implementation - Note: I don't know much about python and I've not coded much in years